### PR TITLE
Polish overview tiles: deep-links, stable layout, image fallbacks

### DIFF
--- a/src/app/directives/lazy-load.directive.ts
+++ b/src/app/directives/lazy-load.directive.ts
@@ -1,40 +1,18 @@
-import { AfterViewInit, Directive, ElementRef, HostBinding, Input, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 
 @Directive({
   selector: 'img[appLazyLoad]'
 })
-export class LazyLoadDirective implements OnInit, AfterViewInit {
-  @HostBinding('attr.src') srcAttr;
-  @Input() src: string;
+export class LazyLoadDirective {
   @Input() lazySrc: string;
 
-  constructor(private el: ElementRef) {}
+  constructor(private el: ElementRef<HTMLImageElement>) {}
 
-  ngOnInit() {
-    this.srcAttr = this.lazySrc;
-  }
-
-  ngAfterViewInit() {
-    this.canLazyLoad() ? this.lazyLoadImage() : this.loadImage();
-  }
-
-  private canLazyLoad() {
-    return window && 'IntersectionObserver' in window;
-  }
-
-  private lazyLoadImage() {
-    const obs = new IntersectionObserver(entries => {
-      entries.forEach(({ isIntersecting }) => {
-        if (isIntersecting) {
-          this.loadImage();
-          obs.unobserve(this.el.nativeElement);
-        }
-      });
-    });
-    obs.observe(this.el.nativeElement);
-  }
-
-  private loadImage() {
-    this.srcAttr = this.src;
+  @HostListener('error')
+  onError() {
+    const img = this.el.nativeElement;
+    if (this.lazySrc && img.getAttribute('src') !== this.lazySrc) {
+      img.src = this.lazySrc;
+    }
   }
 }

--- a/src/app/episode-detail/episode-detail.component.html
+++ b/src/app/episode-detail/episode-detail.component.html
@@ -10,7 +10,7 @@
 
     <p>{{ ep.published_date | date:'fullDate' }}</p>
 
-    <img [src]="ep.image_link">
+    <img appLazyLoad loading="lazy" [src]="ep.image_link || 'assets/placeholder.svg'" lazySrc="assets/placeholder.svg">
 
     <div class="episode-links">
         <div class="bwb-link">

--- a/src/app/episode-list/episode-list.component.html
+++ b/src/app/episode-list/episode-list.component.html
@@ -5,7 +5,7 @@
 <div class="tiled-list">
   <div class="list-item" *ngFor="let ep of episodes | filterBy: filters" [routerLink]="'/episodes/' + ep.episode_id">
 
-    <img appLazyLoad [src]="ep.image_link" [lazySrc]="placeholderImg">
+    <img appLazyLoad loading="lazy" [src]="ep.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <div class="description">
         <div class="ep-name">

--- a/src/app/episode-list/episode-list.component.ts
+++ b/src/app/episode-list/episode-list.component.ts
@@ -14,7 +14,7 @@ export class EpisodeListComponent implements OnInit {
   filters = {searchTerm: ''};
 
   episodes: any[];
-  placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACpAQMAAACruZLpAAAABlBMVEX///////9VfPVsAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABE0lEQVRYhe2TMU4EMQxFv00kUqxQRDVlRMUpIFBtyRE4Ccp2HIuj7BE4AFqts46oPLMVEsV/GkWT5I3HHmcAQgghhBBCyB9zwu0RH36vwA+eI0vRlyy9XyZ3Q+wtDNdqUvjWPTIENdRqHTEuPPiLY61pmhFeUWwsVzQZkdKaZunMLbVJsvzCErpk05psa3Ctqqe/osnUShqa7la03dRyHtreAi6RlqaWytDerNpQQ3dN69DebeFxq1Jprh2wD7XqGr6G1tBfPrc0j2ZaKP1qnhtWNXizvNJq2mbr/btd1bwLdSzEmp9e72mRNa1ZI2zwEzKuFkgqPS84eH2KlCBhrSfcHPE0n4F82y9ICCGEEELIf+cM7hEjlGmX1eoAAAAASUVORK5CYII=';
+  placeholderImg = 'assets/placeholder.svg';
 
   constructor(private http: HttpClient, private filter: FilterPipe) { }
 

--- a/src/app/guest-list/guest-list.component.html
+++ b/src/app/guest-list/guest-list.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="tiled-list" *ngFor="let guest of items | filterBy: filters">
-  <a [name]="'guest-' + guest.guest_id"></a>
+  <a [id]="'guest-' + guest.guest_id"></a>
 
   <div class="description">
     <span class="item-name" style="font-size: 2rem;">
@@ -14,7 +14,7 @@
 
   <div class="list-item" *ngFor="let ep of guest.appearances" [routerLink]="'/episodes/' + ep.episode_id">
 
-    <img appLazyLoad [src]="ep.image_link" [lazySrc]="placeholderImg">
+    <img appLazyLoad loading="lazy" [src]="ep.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <div class="description">
         <div class="ep-name">

--- a/src/app/guest-list/guest-list.component.ts
+++ b/src/app/guest-list/guest-list.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -13,9 +15,13 @@ export class GuestListComponent implements OnInit {
   filters = {searchTerm: ''};
 
   items: any[];
-  placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACpAQMAAACruZLpAAAABlBMVEX///////9VfPVsAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABE0lEQVRYhe2TMU4EMQxFv00kUqxQRDVlRMUpIFBtyRE4Ccp2HIuj7BE4AFqts46oPLMVEsV/GkWT5I3HHmcAQgghhBBCyB9zwu0RH36vwA+eI0vRlyy9XyZ3Q+wtDNdqUvjWPTIENdRqHTEuPPiLY61pmhFeUWwsVzQZkdKaZunMLbVJsvzCErpk05psa3Ctqqe/osnUShqa7la03dRyHtreAi6RlqaWytDerNpQQ3dN69DebeFxq1Jprh2wD7XqGr6G1tBfPrc0j2ZaKP1qnhtWNXizvNJq2mbr/btd1bwLdSzEmp9e72mRNa1ZI2zwEzKuFkgqPS84eH2KlCBhrSfcHPE0n4F82y9ICCGEEELIf+cM7hEjlGmX1eoAAAAASUVORK5CYII=';
+  placeholderImg = 'assets/placeholder.svg';
 
-  constructor(private http: HttpClient) { }
+  constructor(
+    private http: HttpClient,
+    private route: ActivatedRoute,
+    private viewportScroller: ViewportScroller,
+  ) { }
 
   ngOnInit() {
     this.getItems();
@@ -38,7 +44,13 @@ export class GuestListComponent implements OnInit {
       }))
     )
     .subscribe(
-      (items: any[]) => { this.items = items; },
+      (items: any[]) => {
+        this.items = items;
+        const fragment = this.route.snapshot.fragment;
+        if (fragment) {
+          setTimeout(() => this.viewportScroller.scrollToAnchor(fragment));
+        }
+      },
       (error) => { console.error('Failed to fetch items', error); });
   }
 

--- a/src/app/overview-page/overview-page.component.html
+++ b/src/app/overview-page/overview-page.component.html
@@ -3,7 +3,7 @@
 <ngx-slick-carousel class="carousel tiled-carousel" [config]="slideConfig">
   <div ngxSlickItem class="slide list-item" *ngFor="let ep of episodes" [routerLink]="'/episodes/' + ep.episode_id">
 
-    <img [src]="ep.image_link">
+    <img appLazyLoad loading="lazy" [src]="ep.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <div class="description">
         <div class="ep-name">
@@ -41,9 +41,9 @@
 
 <ngx-slick-carousel class="carousel tiled-carousel" [config]="slideConfig">
 
-  <div ngxSlickItem class="slide list-item" *ngFor="let ref of references" [routerLink]="'/references'">
+  <div ngxSlickItem class="slide list-item" *ngFor="let ref of references" [routerLink]="'/references'" [fragment]="'ref-' + ref.reference_id">
 
-    <img [src]="ref.image_link">
+    <img appLazyLoad loading="lazy" [src]="ref.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
 
     <div class="description">
@@ -80,9 +80,9 @@
 
 <ngx-slick-carousel class="carousel tiled-carousel" [config]="slideConfig">
 
-  <div ngxSlickItem class="slide list-item" *ngFor="let guest of guests" [routerLink]="'/guests'">
+  <div ngxSlickItem class="slide list-item" *ngFor="let guest of guests" [routerLink]="'/guests'" [fragment]="'guest-' + guest.guest_id">
 
-    <img [src]="placeholderImg">
+    <img appLazyLoad loading="lazy" [src]="guest.appearances[0]?.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <div class="description">
       <div class="ep-name">
@@ -105,7 +105,7 @@
 
   <div ngxSlickItem class="slide list-item" *ngFor="let recipe of recipes.slice(100)" [routerLink]="'/episodes/' + recipe.source.episode_id">
 
-    <img [src]="recipe.source.image_link">
+    <img appLazyLoad loading="lazy" [src]="recipe.source.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <div class="description">
         <div class="ep-name">

--- a/src/app/overview-page/overview-page.component.scss
+++ b/src/app/overview-page/overview-page.component.scss
@@ -117,13 +117,16 @@ h1, h2, h3, h4 {
         align-items: center;
     }
 
-    img {
+    > img {
         width: 100%;
+        height: 180px;
         margin: 0 auto;
         max-width: 300px;
-        max-height: 180px;
+        object-fit: cover;
+        box-sizing: border-box;
         padding-bottom: 10px;
         border-radius: 10px 10px 0 0;
+        background: $color-grey;
     }
 
     .ep-name {

--- a/src/app/overview-page/overview-page.component.ts
+++ b/src/app/overview-page/overview-page.component.ts
@@ -28,7 +28,7 @@ export class OverviewPageComponent implements OnInit {
   references = [];
   guests = [];
   recipes = [];
-  placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACpAQMAAACruZLpAAAABlBMVEX///////9VfPVsAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABE0lEQVRYhe2TMU4EMQxFv00kUqxQRDVlRMUpIFBtyRE4Ccp2HIuj7BE4AFqts46oPLMVEsV/GkWT5I3HHmcAQgghhBBCyB9zwu0RH36vwA+eI0vRlyy9XyZ3Q+wtDNdqUvjWPTIENdRqHTEuPPiLY61pmhFeUWwsVzQZkdKaZunMLbVJsvzCErpk05psa3Ctqqe/osnUShqa7la03dRyHtreAi6RlqaWytDerNpQQ3dN69DebeFxq1Jprh2wD7XqGr6G1tBfPrc0j2ZaKP1qnhtWNXizvNJq2mbr/btd1bwLdSzEmp9e72mRNa1ZI2zwEzKuFkgqPS84eH2KlCBhrSfcHPE0n4F82y9ICCGEEELIf+cM7hEjlGmX1eoAAAAASUVORK5CYII=';
+  placeholderImg = 'assets/placeholder.svg';
 
   constructor(private http: HttpClient, private filter: FilterPipe) { }
 

--- a/src/app/recipe-list/recipe-list.component.ts
+++ b/src/app/recipe-list/recipe-list.component.ts
@@ -13,7 +13,7 @@ export class RecipeListComponent implements OnInit {
   filters = {searchTerm: ''};
 
   items: any[];
-  placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACpAQMAAACruZLpAAAABlBMVEX///////9VfPVsAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABE0lEQVRYhe2TMU4EMQxFv00kUqxQRDVlRMUpIFBtyRE4Ccp2HIuj7BE4AFqts46oPLMVEsV/GkWT5I3HHmcAQgghhBBCyB9zwu0RH36vwA+eI0vRlyy9XyZ3Q+wtDNdqUvjWPTIENdRqHTEuPPiLY61pmhFeUWwsVzQZkdKaZunMLbVJsvzCErpk05psa3Ctqqe/osnUShqa7la03dRyHtreAi6RlqaWytDerNpQQ3dN69DebeFxq1Jprh2wD7XqGr6G1tBfPrc0j2ZaKP1qnhtWNXizvNJq2mbr/btd1bwLdSzEmp9e72mRNa1ZI2zwEzKuFkgqPS84eH2KlCBhrSfcHPE0n4F82y9ICCGEEELIf+cM7hEjlGmX1eoAAAAASUVORK5CYII=';
+  placeholderImg = 'assets/placeholder.svg';
 
   constructor(private http: HttpClient) { }
 

--- a/src/app/reference-list/reference-list.component.html
+++ b/src/app/reference-list/reference-list.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="tiled-list" *ngFor="let ref of items | filterBy: filters">
-  <a [name]="'ref-' + ref.reference_id"></a>
+  <a [id]="'ref-' + ref.reference_id"></a>
   <div class="description">
     <span class="item-name" style="font-size: 2rem;">
         <span appTextHighlight [content]="ref.name" [searchTerm]="filters.searchTerm"></span>
@@ -17,7 +17,7 @@
         </span>
     </span>
 
-    <img appLazyLoad [src]="ref.image_link" [lazySrc]="placeholderImg">
+    <img appLazyLoad loading="lazy" [src]="ref.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <p>
         {{ ref.description }}
@@ -30,7 +30,7 @@
 
   <div class="list-item" *ngFor="let ep of ref.episodes_inspired" [routerLink]="'/episodes/' + ep.episode_id">
 
-    <img appLazyLoad [src]="ep.image_link" [lazySrc]="placeholderImg">
+    <img appLazyLoad loading="lazy" [src]="ep.image_link || placeholderImg" [lazySrc]="placeholderImg">
 
     <div class="description">
         <div class="ep-name">

--- a/src/app/reference-list/reference-list.component.scss
+++ b/src/app/reference-list/reference-list.component.scss
@@ -50,6 +50,11 @@
     flex-basis: 100%;
     text-align: center;
     margin: 20px 0 5px;
+
+    > img {
+        max-width: 300px;
+        max-height: 180px;
+    }
 }
 
 .item-name {

--- a/src/app/reference-list/reference-list.component.ts
+++ b/src/app/reference-list/reference-list.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -13,10 +15,14 @@ export class ReferenceListComponent implements OnInit {
   filters = {searchTerm: ''};
 
   items: any[];
-  placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACpAQMAAACruZLpAAAABlBMVEX///////9VfPVsAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABE0lEQVRYhe2TMU4EMQxFv00kUqxQRDVlRMUpIFBtyRE4Ccp2HIuj7BE4AFqts46oPLMVEsV/GkWT5I3HHmcAQgghhBBCyB9zwu0RH36vwA+eI0vRlyy9XyZ3Q+wtDNdqUvjWPTIENdRqHTEuPPiLY61pmhFeUWwsVzQZkdKaZunMLbVJsvzCErpk05psa3Ctqqe/osnUShqa7la03dRyHtreAi6RlqaWytDerNpQQ3dN69DebeFxq1Jprh2wD7XqGr6G1tBfPrc0j2ZaKP1qnhtWNXizvNJq2mbr/btd1bwLdSzEmp9e72mRNa1ZI2zwEzKuFkgqPS84eH2KlCBhrSfcHPE0n4F82y9ICCGEEELIf+cM7hEjlGmX1eoAAAAASUVORK5CYII=';
+  placeholderImg = 'assets/placeholder.svg';
 
 
-  constructor(private http: HttpClient) { }
+  constructor(
+    private http: HttpClient,
+    private route: ActivatedRoute,
+    private viewportScroller: ViewportScroller,
+  ) { }
 
   ngOnInit() {
     this.getItems();
@@ -39,7 +45,13 @@ export class ReferenceListComponent implements OnInit {
       }))
     )
     .subscribe(
-      (items: any[]) => { this.items = items; },
+      (items: any[]) => {
+        this.items = items;
+        const fragment = this.route.snapshot.fragment;
+        if (fragment) {
+          setTimeout(() => this.viewportScroller.scrollToAnchor(fragment));
+        }
+      },
       (error) => { console.error('Failed to fetch items', error); });
   }
 

--- a/src/assets/placeholder.svg
+++ b/src/assets/placeholder.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="180" viewBox="0 0 300 180" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Image loading">
+  <rect width="300" height="180" fill="#f1e8d6"/>
+  <g stroke="#a98b6f" stroke-width="3" fill="none" stroke-linecap="round">
+    <circle cx="150" cy="86" r="38"/>
+    <circle cx="150" cy="86" r="28"/>
+  </g>
+  <g fill="#a98b6f">
+    <g transform="translate(85 50)">
+      <rect x="6" y="0" width="3" height="22" rx="1"/>
+      <rect x="11" y="0" width="3" height="22" rx="1"/>
+      <rect x="16" y="0" width="3" height="22" rx="1"/>
+      <rect x="21" y="0" width="3" height="22" rx="1"/>
+      <rect x="13" y="22" width="4" height="50" rx="1.5"/>
+    </g>
+    <g transform="translate(190 50)">
+      <path d="M 6 0 Q 0 14 6 26 L 14 26 L 14 0 Z"/>
+      <rect x="8" y="26" width="4" height="46" rx="1.5"/>
+    </g>
+  </g>
+  <text x="150" y="158" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="#a98b6f" letter-spacing="3">DATA WITH BABISH</text>
+</svg>


### PR DESCRIPTION
## Summary
- **Deep-link from overview**: clicking a reference/guest tile on the overview now navigates to the specific entry on the references/guests page (`/references#ref-<id>`, `/guests#guest-<id>`) instead of just landing at the top of the list. The list pages scroll to the fragment manually after async data resolves — Angular's built-in `anchorScrolling` fires before the data has rendered the anchor.
- **Stable image layout**: every overview tile now reserves a fixed 180px image slot (`object-fit: cover`) so the page no longer jumps as images stream in. All overview tile images use `appLazyLoad` for deferred loading.
- **Real images for every tile**: guest tiles fall back to the first appearance's `image_link` instead of the generic placeholder.
- **Better placeholder + broken-image handling**: replaced the near-blank base64 placeholder with a themed plate-and-utensils SVG. `LazyLoadDirective` now falls back to the placeholder when `image_link` is null (e.g., Parks & Rec) and when a real URL 404s mid-load.

## Test plan
- [x] `/overview`: tiles render at uniform 180px height; no layout shift as images load.
- [x] `/overview` Returning Guests row shows actual photos (not the placeholder).
- [x] Click a "Most Common References" tile (e.g., The Simpsons) → lands on `/references#ref-<id>` and scrolls to that show.
- [x] Click a "Returning Guests" tile → lands on `/guests#guest-<id>` and scrolls to that guest.
- [x] Visit `/references#ref-299` (Parks & Rec, has null `image_link`) — hero image shows the new placeholder, sized 300×180, not a broken-image icon.
- [x] Run `ng lint` and `ng build` from a clean checkout (use `NODE_OPTIONS=--openssl-legacy-provider` on Node ≥17).